### PR TITLE
 installation for autoconf and automake

### DIFF
--- a/opensmile/install_opensmile.sh
+++ b/opensmile/install_opensmile.sh
@@ -9,7 +9,7 @@ echo $result
 #Else the wget command skips download if file is already present
 wget -nc http://www.audeering.com/research-and-open-source/files/openSMILE-2.1.0.tar.gz
 tar -zxvf openSMILE-2.1.0.tar.gz
-sudo apt-get install build-essential libtool
+sudo apt-get install build-essential libtool autoconf automake xutils-dev
 
 #PORTAUDIO INSTALLATION
 echo "run this in the directory where you want to install portaudio."


### PR DESCRIPTION
Installation is needed for installing opensmile toolkit and thus was added to the code if it is a fresh os with no dependencies installed.
As on my new laptop while running the code of install_opensmile.sh it gave error in the file saying autoconf not found and automake: command not found